### PR TITLE
Switch to FUSE3

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ tool 'fosread' can work directly with your device but it is limited for an
 console use.
 The tool 'fosmount' uses FUSE to mount in read-only your device in your
 tree. And you can convert the smaky's text files with smascii. You can
-compile 'fosmount' with >=fuse-2.6.x.
+compile 'fosmount' with >=fuse-3.x.
 'fosrec' can be used to restore all deleted files. To restore only one file,
 this action must be performed by 'fosread'.
 

--- a/configure
+++ b/configure
@@ -43,7 +43,7 @@ show_help(){
   echo "  --disable-tools             do not build fosread, fosrec and smascii tools"
   echo "  --enable-fosmount           build fosmount FUSE extension"
   echo "  --disable-fosmount          do not build fosmount FUSE extension"
-  echo "  --with-fuse-dir=DIR         check for libfuse installed in DIR"
+  echo "  --with-fuse-dir=DIR         check for libfuse3 installed in DIR"
   echo ""
   echo "Advanced options (experts only):"
   echo "  --arch=ARCH                 force architecture"
@@ -863,7 +863,7 @@ fi
 echolog "Checking for Blupi ..."
 
 #################################################
-#   check for libfuse
+#   check for libfuse3
 #################################################
 if test "$fosmount" = "yes"; then
   if [ -n "$libfusedir" ]; then
@@ -871,10 +871,10 @@ if test "$fosmount" = "yes"; then
     check_ldflags -L$libfusedir
   fi
 
-  add_cppflags -DFUSE_USE_VERSION=26
+  add_cppflags -DFUSE_USE_VERSION=30
 
-  echolog "Checking for libfuse ..."
-  check_lib_pkgcfg fuse fuse.h fuse_main -lfuse || die "Error, can't find libfuse !"
+  echolog "Checking for libfuse3 ..."
+  check_lib_pkgcfg fuse3 fuse.h fuse_main_real -lfuse3 || die "Error, can't find libfuse !"
 fi
 
 #################################################

--- a/fosmount/Makefile
+++ b/fosmount/Makefile
@@ -8,7 +8,7 @@ FOSMOUNT_SRCS = fosmount.c
 FOSMOUTN_MAN = $(FOSMOUNT).1
 
 APPS_CPPFLAGS = -I../libfosfat -I../libfosgra $(CFG_CPPFLAGS) $(CPPFLAGS)
-APPS_LDFLAGS = -L../libfosfat -L../libfosgra -lfosfat -lfosgra -lfuse $(CFG_LDFLAGS) $(LDFLAGS)
+APPS_LDFLAGS = -L../libfosfat -L../libfosgra -lfosfat -lfosgra -lfuse3 $(CFG_LDFLAGS) $(LDFLAGS)
 
 MANS = $(FOSMOUTN_MAN)
 

--- a/fosmount/fosmount.c
+++ b/fosmount/fosmount.c
@@ -359,7 +359,7 @@ fos_readlink (const char *path, char *dst, size_t size)
  * return 0 for success
  */
 static int
-fos_getattr (const char *path, struct stat *stbuf)
+fos_getattr (const char *path, struct stat *stbuf, struct fuse_file_info *fi)
 {
   int ret = 0;
   char *location;
@@ -399,7 +399,7 @@ fos_getattr (const char *path, struct stat *stbuf)
  */
 static int
 fos_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
-             off_t offset, struct fuse_file_info *fi)
+             off_t offset, struct fuse_file_info *fi, enum fuse_readdir_flags flags)
 {
   int ret = -ENOENT;
   char *location;
@@ -411,7 +411,7 @@ fos_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
   location = trim_fosname (path);
 
   /* First entries */
-  filler (buf, "..", NULL, 0);
+  filler (buf, "..", NULL, 0, 0);
 
   /* Files and directories */
   files = fosfat_list_dir (fosfat, location);
@@ -450,7 +450,7 @@ fos_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
       *(name + strlen (name) - 4) = '\0';
 
     /* Add entry in the file list */
-    filler (buf, name, st, 0);
+    filler (buf, name, st, 0, 0);
     free (st);
     free (name);
   }


### PR DESCRIPTION
This changes Fosfat to use FUSE3 as FUSE2 is no longer maintained.

Since I don't own anything related to SMAKY, I tested this using "Progr.di" from https://www.smaky.ch/wp-content/uploads/2023/10/Progr.zip (via https://smaky.ch/le-smaky-infini-libre/) and it yielded identical results regarding both file contents and metadata.

I did not rename `$libfusedir` and `--with-fuse-dir` in `configure` but can do that as well if you prefer.

I plan to apply this patch to fosfat as-is currently in Debian and update it to 1.0 afterwards.